### PR TITLE
Add initial release-build.yml workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,28 @@
+# See LICENSE file in this repo for license details.
+
+name: Release Build
+
+on:
+  push:
+    tags:
+
+      # The imported workflow performs necessary logic to separate "stable"
+      # release builds from "prerelease" builds. Here we match any semver tag.
+      - 'v[0-9]+.[0-9]+.*'
+
+jobs:
+  release_build:
+    name: Generate release build
+    uses: atc0005/shared-project-resources/.github/workflows/release-build.yml@add-release-build-importable-workflow
+    with:
+
+      # NOTE: Library projects such as atc0005/go-nagios or
+      # atc0005/go-teams-notify explicitly set this value to false to avoid
+      # generating release assets as part of creating an automated release
+      # upon pushing a tag.
+      #
+      # See also:
+      #
+      # - https://github.com/atc0005/shared-project-resources/pull/131
+      generate-assets: false
+      # generate-assets: true


### PR DESCRIPTION
Add untested workflow which:

- imports workflow from a PR branch
- explicitly disables release asset generation

I'll toggle settings in follow-up PRs to test the behavior of the imported workflow logic.