### PR TITLE
Switch build image for development branch

### DIFF
--- a/dependabot/docker/builds/Dockerfile
+++ b/dependabot/docker/builds/Dockerfile
@@ -13,7 +13,7 @@
 
 # https://github.com/atc0005/go-ci/releases
 # https://github.com/atc0005/go-ci/pkgs/container/go-ci
-FROM ghcr.io/atc0005/go-ci:go-ci-oldstable-build-v0.11.5
+FROM ghcr.io/atc0005/go-ci:go-ci-unstable-build-v0.11.5
 
 # Setup isolated build environment with a full copy of the Git repo contents
 # MINUS any file or path listed in the .dockerignore file at the root of this


### PR DESCRIPTION
Switch from stable build image to unstable build image.

This allows generating test/dev releases from the next available Go
version along with any other test/dev changes.
