### PR TITLE
Switch canary Dockerfile to Go release candidate

### DIFF
--- a/dependabot/docker/go/Dockerfile
+++ b/dependabot/docker/go/Dockerfile
@@ -15,4 +15,4 @@
 # binaries) to reflect that version of Go.
 
 # https://hub.docker.com/_/golang
-FROM golang:1.19.11
+FROM golang:1.21rc2


### PR DESCRIPTION
Intentionally chose one version back to test upcoming Dependabot changes.