### PR TITLE
Downgrade build image vesion to test Dependabot

### DIFF
--- a/dependabot/docker/builds/Dockerfile
+++ b/dependabot/docker/builds/Dockerfile
@@ -13,7 +13,7 @@
 
 # https://github.com/atc0005/go-ci/releases
 # https://github.com/atc0005/go-ci/pkgs/container/go-ci
-FROM ghcr.io/atc0005/go-ci:go-ci-unstable-build-v0.11.5
+FROM ghcr.io/atc0005/go-ci:go-ci-unstable-build-v0.11.4
 
 # Setup isolated build environment with a full copy of the Git repo contents
 # MINUS any file or path listed in the .dockerignore file at the root of this


### PR DESCRIPTION
Drop patch version from v0.11.5 to v0.11.4. Incoming Dependabot changes should offer an update back to v0.11.5.