### PR TITLE
Remove Go canary Dockerfile version constraint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -131,8 +131,6 @@ updates:
       - dependency-type: "all"
     commit-message:
       prefix: "canary"
-    ignore:
-      - dependency-name: "golang"
 
   ######################################################################
   # Monitor images used to build project releases


### PR DESCRIPTION
I removed the specific upper/lower bounds, but forgot to remove the actual ignore option.