### PR TITLE
Add .gitattributes file to ignore merge conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Copyright 2023 Adam Chalkley
+#
+# https://github.com/atc0005/hello-world
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# https://medium.com/@porteneuve/how-to-make-git-preserve-specific-files-while-merging-18c92343826b
+# https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes#Merge-Strategies
+
+# The development branch tracks a different version of Go; prevent merging
+# conflicts to files in this path.
+dependabot/ merge=ours


### PR DESCRIPTION
Ignore conflicts with files in the /dependabot path.