### PR TITLE
Fix .gitattributres file syntax

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,13 +1,22 @@
-# Copyright 2023 Adam Chalkley
-#
-# https://github.com/atc0005/hello-world
-#
-# Licensed under the MIT License. See LICENSE file in the project root for
-# full license information.
+# See LICENSE file in this repo for license details.
 
 # https://medium.com/@porteneuve/how-to-make-git-preserve-specific-files-while-merging-18c92343826b
 # https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes#Merge-Strategies
 
 # The development branch tracks a different version of Go; prevent merging
-# conflicts to files in this path.
-dependabot/ merge=ours
+# conflicts to these specific files.
+#
+# NOTE: You still need to configure a 'ours' merge strategy in order to have
+# these settings take effect.
+#
+# Per repo:
+#
+# $ cd /path/to/repo
+# $ git config merge.ours.driver true
+#
+# Globally:
+#
+# $ git config --global merge.ours.driver true
+
+dependabot/docker/builds/Dockerfile merge=ours
+dependabot/docker/go/Dockerfile merge=ours


### PR DESCRIPTION
Evidently directory syntax is not supported, only specific files. Update accordingly.