### PR TITLE
Fix errcheck linting errors

### DIFF
--- a/cmd/hw/config.go
+++ b/cmd/hw/config.go
@@ -47,8 +47,8 @@ func Version() string {
 // usage is a custom override for the default Help text provided by the flag
 // package. Here we prepend some additional metadata to the existing output.
 func usage() {
-	fmt.Fprintln(flag.CommandLine.Output(), "\n"+Version()+"\n")
-	fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
+	_, _ = fmt.Fprintln(flag.CommandLine.Output(), "\n"+Version()+"\n")
+	_, _ = fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
 	flag.PrintDefaults()
 }
 


### PR DESCRIPTION
Resolve `return value of fmt.Fprintf is not checked`` errors by
explicitly discarding return values (potential error, bytes written)
since we do not need them and the potential for failure (in this
particular use case) is *highly* unlikely.
