### PR TITLE
Update project to Go 1.22 series

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -112,8 +112,8 @@ updates:
     ignore:
       - dependency-name: "golang"
         versions:
-          - ">= 1.22.0"
-          - "< 1.21.0"
+          - ">= 1.23.0"
+          - "< 1.22.0"
 
   - package-ecosystem: docker
     directory: "/dependabot/docker/go"


### PR DESCRIPTION
Update Dependabot configuration for Dockerfile to ignore Go releases outside
of the Go 1.22 release series

NOTE: We intentionally do *not* update the Go module version; bumping
the Go module version would indicate that this project *requires* a
newer Go version for functionality provided by that version (and that
is not yet the case).
