### PR TITLE
Test using x.y.Z value with exclusion range

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -112,8 +112,8 @@ updates:
     ignore:
       - dependency-name: "golang"
         versions:
-          - ">= 1.22"
-          - "< 1.21"
+          - ">= 1.22.0"
+          - "< 1.21.0"
 
   - package-ecosystem: docker
     directory: "/dependabot/docker/go"


### PR DESCRIPTION
Test whether adding the trailing `.0` prevents Dependabot from offering RC versions of Go as stable version update PRs.