### PR TITLE
go.mod: update minimum Go version to 1.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/atc0005/hello-world
 
-go 1.20
+go 1.23.0


### PR DESCRIPTION
## Overview

The Go project now unconditionally updates the minimum Go version for
`golang.org/x/` dependencies to be at least `1.(N-1).0`, where Go `1.N` is
the most recent major Go release, and Go `1.(N-1)` is the previous major
Go release.

Since this project uses dependencies associated with `golang.org/x`
repositories this project's go.mod file is also updated to reflect
the new minimum Go version.

## Changes

1. `go get go@1.23.0`
2. `go mod tidy`
3. `go mod vendor`
4. `go fix ./...`
5. `go mod edit -toolchain=none`

## References

> all: upgrade go directive to at least 1.23.0 [generated]
>
> By now Go 1.24.0 has been released, and Go 1.22 is no longer supported
> per the Go Release Policy (https://go.dev/doc/devel/release#policy).
>
> For golang/go#69095.

See also:

- golang/crypto@89ff08d67c4d79f9ac619aaf1f7388888798651f
- golang/sys@74cfc93a99be6ca6f193856132e6799065b071af
