### PR TITLE
Disable release discussions

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -35,3 +35,6 @@ jobs:
 
       # Explicitly specify the same value as the default for imported workflow.
       generate-assets: true
+
+      # Opt out of release discussions.
+      create-discussion: false


### PR DESCRIPTION
Override default option to create release discussions by explicitly setting the new `create-discussion` workflow input to `false`.